### PR TITLE
Update Задание для кандидатов. Выполнить ревью кода.sql

### DIFF
--- a/Задание для кандидатов. Выполнить ревью кода.sql
+++ b/Задание для кандидатов. Выполнить ревью кода.sql
@@ -4,7 +4,7 @@ as
 set nocount on
 begin
 	declare @RowCount int = (select count(*) from syn.SA_CustomerSeasonal)
-	declare @ErrorMessage varchar(max)
+		,@ErrorMessage varchar(max)
 
 -- Проверка на корректность загрузки
 	if not exists (


### PR DESCRIPTION
• Для объявления переменных declare используется один раз. Дальнейшее переменные перечисляются через запятую с новой строки, если явно не требуется писать declare


Скорректировал объявление переменных declare