### PR TITLE
Update Задание для кандидатов. Выполнить ревью кода.sql

### DIFF
--- a/Задание для кандидатов. Выполнить ревью кода.sql
+++ b/Задание для кандидатов. Выполнить ревью кода.sql
@@ -4,7 +4,7 @@ set nocount on
 begin
 	declare
 		@RowCount int = (select count(*) from syn.SA_CustomerSeasonal)
-		,@ErrorMessage varchar(max)
+		,@ErrorMessage varchar(8000)
 
 	-- Проверка на корректность загрузки
 	if not exists (


### PR DESCRIPTION
• Рекомендуется при объявлении типов не использовать длину поля max
    o Пример:
        § varchar(8000)
        § nvarchar(4000)


Изменил объём для поля "ErrorMessage" согласно рекомендации